### PR TITLE
Extensibility optimization

### DIFF
--- a/src/api/middleware/custom_route_events.js
+++ b/src/api/middleware/custom_route_events.js
@@ -8,7 +8,7 @@ import ResponseData from "../../models/response_data.js";
  */
 export default function customRouteEvent(app) {
   return (req, res, next) => {
-    app.emitter.on("customRouteEnd", () => {
+    app.emitter.once("customRouteEnd", () => {
       next();
     });
     app.onCustomRoute.triggerListeners(new ResponseData(req, res));

--- a/src/api/routers/admin.js
+++ b/src/api/routers/admin.js
@@ -79,7 +79,7 @@ class AdminAPI {
 
       const responseData = new ResponseData(req, res, { backupFileName });
 
-      this.app.emitter.on("backupDatabaseEnd", () => {
+      this.app.emitter.once("backupDatabaseEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(200).json(responseData.formatGeneralResponse());
       });

--- a/src/api/routers/auth.js
+++ b/src/api/routers/auth.js
@@ -97,7 +97,7 @@ class AuthApi {
 
       const responseData = new ResponseData(req, res, createdUser);
 
-      this.app.emitter.on("RegisterUserEnd", () => {
+      this.app.emitter.once("RegisterUserEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(201).json(responseData.formatGeneralResponse());
       });
@@ -190,7 +190,7 @@ class AuthApi {
         user: createdAdmin[0].username,
       });
 
-      this.app.emitter.on("registerAdminEnd", () => {
+      this.app.emitter.once("registerAdminEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(201).json(responseData.formatGeneralResponse());
       });
@@ -226,7 +226,7 @@ class AuthApi {
         user: req.session.user,
       });
 
-      this.app.emitter.on("loginUserEnd", () => {
+      this.app.emitter.once("loginUserEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(200).send(responseData.formatGeneralResponse());
       });
@@ -259,7 +259,7 @@ class AuthApi {
       const responseData = new ResponseData(req, res, {
         user: req.session.user,
       });
-      this.app.emitter.on("loginAdminEnd", () => {
+      this.app.emitter.once("loginAdminEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(200).send(responseData.formatGeneralResponse());
       });
@@ -276,7 +276,7 @@ class AuthApi {
     return async (req, res, next) => {
       const responseData = new ResponseData(req, res, "User Logged Out");
 
-      this.app.emitter.on("logoutEnd", () => {
+      this.app.emitter.once("logoutEnd", () => {
         if (responseData.responseSent()) return null;
         delete req.session.user;
         res.status(200).json(responseData.formatGeneralResponse());

--- a/src/api/routers/crud.js
+++ b/src/api/routers/crud.js
@@ -103,7 +103,7 @@ class CrudApi {
 
       // Get the pnpd_event object for this event
       //
-      this.app.emitter.on("getAllRowsEnd", () => {
+      this.app.emitter.once("getAllRowsEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(200).json(responseData.formatAllResponse());
       });
@@ -136,7 +136,7 @@ class CrudApi {
       const responseData = new ResponseData(req, res, { table, rows: row });
 
       // Once all "getOneRow" events have finished execution, the "getOneRowEnd" event fires.
-      this.app.emitter.on("getOneRowEnd", () => {
+      this.app.emitter.once("getOneRowEnd", () => {
         // If an event sends a response to the client, we won't try to resend it.
         if (responseData.responseSent()) return null;
         res.status(200).json(responseData.formatOneResponse());
@@ -170,7 +170,7 @@ class CrudApi {
         rows: createdRow,
       });
 
-      this.app.emitter.on("createOneRowEnd", () => {
+      this.app.emitter.once("createOneRowEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(201).json(responseData.formatOneResponse());
       });
@@ -208,7 +208,7 @@ class CrudApi {
         rows: updatedRow,
       });
 
-      this.app.emitter.on("updateOneRowEnd", () => {
+      this.app.emitter.once("updateOneRowEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(200).json(responseData.formatOneResponse());
       });
@@ -239,7 +239,7 @@ class CrudApi {
 
       const responseData = new ResponseData(req, res, { table, rows: row });
 
-      this.app.emitter.on("deleteOneRowEnd", () => {
+      this.app.emitter.once("deleteOneRowEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(204).end();
       });

--- a/src/api/routers/schema.js
+++ b/src/api/routers/schema.js
@@ -56,7 +56,7 @@ class SchemaApi {
 
       const responseData = new ResponseData(req, res, { allTableMeta });
 
-      this.app.emitter.on("getTableMetaEnd", () => {
+      this.app.emitter.once("getTableMetaEnd", () => {
         if (responseData.responseSent()) return null;
         res.json({ tables: allTableMeta });
       });
@@ -76,7 +76,7 @@ class SchemaApi {
       await table.create();
 
       const responseData = new ResponseData(req, res, { table });
-      this.app.emitter.on("createTableEnd", () => {
+      this.app.emitter.once("createTableEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(200).json({ table });
       });
@@ -100,7 +100,7 @@ class SchemaApi {
 
       const responseData = new ResponseData(req, res, { oldTable, newTable });
 
-      this.app.emitter.on("updateTableEnd", () => {
+      this.app.emitter.once("updateTableEnd", () => {
         if (responseData.responseSent()) return null;
         res.json({ table: newTable });
       });
@@ -123,7 +123,7 @@ class SchemaApi {
 
       const responseData = new ResponseData(req, res, { tableToDelete });
 
-      this.app.emitter.on("dropTableEnd", () => {
+      this.app.emitter.once("dropTableEnd", () => {
         if (responseData.responseSent()) return null;
         res.status(204).end();
       });

--- a/src/models/pnpd_event.js
+++ b/src/models/pnpd_event.js
@@ -23,10 +23,10 @@ export default class PinnipedEvent {
         // Invoke the handler function passed in via the add method in index.js
         await handler(responseData);
         this.count--;
-        this.conditionalEndTrigger();
       } else {
         this.count--;
       }
+      this.conditionalEndTrigger();
     });
   };
 


### PR DESCRIPTION
Fixed two bugs:
1. The `end` event that fires after all of an event's callbacks have returned was registering a callback for that event each time a route handler was run. Now `once` is used instead so that the listener removes itself from the listener list before executing.
2. The trigger for whether an `end` event would fire wasn't always firing at the right time because of where it was being conditionally checked and fired.